### PR TITLE
fix: correct comment for function description

### DIFF
--- a/Graph/BFS_Graph/bfs.cpp
+++ b/Graph/BFS_Graph/bfs.cpp
@@ -48,7 +48,7 @@ int main()
 	int start_vertex; // vertex from which you want your DFS to start
 	cin>>start_vertex;
 	
-	bfs(start_vertex); //  performing DFS from vertex 1
+	bfs(start_vertex); //  performing BFS from vertex 1
 	
 	
 }


### PR DESCRIPTION
@SrijanSriv 
<Do NOT delete this template>
Description: In line 51, call is bein made to `bfs` function but the comment read `DFS`

#### Checklist

- [x] I've followed the Contributing guidelines provided in the repository.
- [x] I've made the changes which were demanded in the linked issue.
- [x] My code gave a clean output on debugging. (NO warnings/errors)
